### PR TITLE
Owin

### DIFF
--- a/lib/JWTSecurityTokenHandler.cs
+++ b/lib/JWTSecurityTokenHandler.cs
@@ -110,7 +110,7 @@ namespace System.IdentityModel.Tokens
                     throw new ArgumentNullException("value");
                 }
 
-                outboundAlgorithmMap = value;
+                inboundAlgorithmMap = value;
             }
         }
 


### PR DESCRIPTION
JwtSecurityTokenHandler.InboundAlgorithmMap.set was setting outboundAlgorithmMap instead of inboundAlgorithmMap 
