### PR TITLE
Setting InboundAlgorithmMap sets wrong backing field

### DIFF
--- a/lib/JWTSecurityTokenHandler.cs
+++ b/lib/JWTSecurityTokenHandler.cs
@@ -92,7 +92,7 @@ namespace System.IdentityModel.Tokens
                     throw new ArgumentNullException("value");
                 }
 
-                outboundAlgorithmMap = value;
+                inboundAlgorithmMap = value;
             }
         }
 


### PR DESCRIPTION
Setting InboundAlgorithmMap's value sets the incorrect backing field. It sets 'outboundAlgorithmMap' when it should be 'inboundAlgorithmMap'.
